### PR TITLE
grpc: Wait until all go routines exit in Close()

### DIFF
--- a/internal/transport/http2_client.go
+++ b/internal/transport/http2_client.go
@@ -1023,6 +1023,7 @@ func (t *http2Client) Close(err error) {
 	case <-timer.C:
 		t.logger.Infof("Failed to write a GOAWAY frame as part of connection close after %s. Giving up and closing the transport.", goAwayLoopyWriterTimeout)
 	}
+	<-t.readerDone
 	t.cancel()
 	t.conn.Close()
 	channelz.RemoveEntry(t.channelz.ID)


### PR DESCRIPTION
It was not guaranteed that when `transport.Close()` returned, the reader go-routines terminated. All the other channels like,  `ctxDone`, `writerDone`, `goAway` are being waited upon for a signal

To ensure that `transport.Close()` only return after the reader go-routine terminates:

- Wait for the `readerDone` channel to signal the completion 

This fixes: https://github.com/grpc/grpc-go/issues/2869

RELEASE NOTES:

grpc: Wait until reader go routine exits in transport.Close()