### PR TITLE
call target URI child resolver unconditionaly

### DIFF
--- a/internal/resolver/delegatingresolver/delegatingresolver.go
+++ b/internal/resolver/delegatingresolver/delegatingresolver.go
@@ -1,0 +1,126 @@
+/*
+ *
+ * Copyright 2017 gRPC authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+// Package prxyresolver implements the default resolver that creates child
+// resolvers to resolver targetURI as well as proxy adress.
+
+package delegatingresolver
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"os"
+
+	"google.golang.org/grpc/resolver"
+	"google.golang.org/grpc/serviceconfig"
+)
+
+type delegatingResolver struct {
+	target         resolver.Target
+	cc             resolver.ClientConn
+	isProxy        bool
+	targetResolver resolver.Resolver
+	proxyResolver  resolver.Resolver
+	targetAddrs    []resolver.Address
+	proxyAddrs     []resolver.Address
+	ctx            context.Context
+	cancel         context.CancelFunc
+}
+
+type innerClientConn struct {
+	cc           resolver.ClientConn
+	parent       *delegatingResolver
+	resolverType string
+}
+
+var (
+	// The following variable will be overwritten in the tests.
+	httpProxyFromEnvironment = http.ProxyFromEnvironment
+)
+
+func New(target resolver.Target, cc resolver.ClientConn, opts resolver.BuildOptions, targetResolverBuilder resolver.Builder) (resolver.Resolver, error) {
+	var err error
+	r := &delegatingResolver{
+		target: target,
+		cc:     cc,
+	}
+	proxyURI := os.Getenv("HTTPS_PROXY")
+	if proxyURI == "" {
+		proxyURI = os.Getenv("HTTP_PROXY")
+	}
+	r.isProxy = true
+	if proxyURI == "" {
+		r.isProxy = false
+	}
+
+	r.targetResolver, err = targetURIResolver(target, cc, opts, targetResolverBuilder, r)
+
+	if err != nil {
+		return nil, err
+	}
+	return r, nil
+}
+
+func targetURIResolver(target resolver.Target, cc resolver.ClientConn, opts resolver.BuildOptions, targetResolverBuilder resolver.Builder, resolver *delegatingResolver) (resolver.Resolver, error) {
+	targetBuilder := targetResolverBuilder
+	if targetBuilder == nil {
+		return nil, fmt.Errorf("resolver for target scheme %q not found", target.URL.Scheme)
+	}
+	return targetBuilder.Build(target, &innerClientConn{cc, resolver, "target"}, opts)
+}
+
+func (r *delegatingResolver) ResolveNow(o resolver.ResolveNowOptions) {
+
+	r.targetResolver.ResolveNow(o)
+}
+
+func (r *delegatingResolver) Close() {
+
+	r.targetResolver.Close()
+
+}
+
+// UpdateState intercepts state updates from the child DNS resolver.
+func (icc *innerClientConn) UpdateState(state resolver.State) error {
+	icc.parent.targetAddrs = state.Addresses
+	return icc.parent.cc.UpdateState(state)
+
+}
+
+// ReportError intercepts errors from the child DNS resolver.
+func (icc *innerClientConn) ReportError(err error) {
+	icc.parent.cc.ReportError(err)
+}
+
+func (icc *innerClientConn) NewAddress(addrs []resolver.Address) {
+	if icc.resolverType == "target" {
+
+		icc.parent.cc.NewAddress(addrs)
+	}
+}
+
+// ParseServiceConfig parses the provided service config and returns an
+// object that provides the parsed config.
+func (icc *innerClientConn) ParseServiceConfig(serviceConfigJSON string) *serviceconfig.ParseResult {
+	fmt.Printf("config received by delegating resolver : %v \n", serviceConfigJSON)
+	if icc.resolverType == "target" {
+		return icc.parent.cc.ParseServiceConfig(serviceConfigJSON)
+	}
+	return nil
+}

--- a/internal/resolver/delegatingresolver/delegatingresolver_test.go
+++ b/internal/resolver/delegatingresolver/delegatingresolver_test.go
@@ -1,0 +1,53 @@
+package delegatingresolver
+
+import (
+	"testing"
+
+	"google.golang.org/grpc/internal/testutils"
+	"google.golang.org/grpc/resolver"
+	"google.golang.org/grpc/resolver/manual"
+	"google.golang.org/grpc/serviceconfig"
+)
+
+// TestDelegatingResolverNoProxy verifies the behavior of the delegating resolver when no proxy is configured.
+func TestDelegatingResolverNoProxy(t *testing.T) {
+	t.Setenv("HTTPS_PROXY", "")               // Explicitely set proxy enviornment to empty to mimic no proxy enviornment set
+	mr := manual.NewBuilderWithScheme("test") // Set up a manual resolver to control the address resolution.
+	target := "test:///localhost:1234"
+
+	stateCh := make(chan resolver.State, 1)
+	updateStateF := func(s resolver.State) error {
+		select {
+		case stateCh <- s:
+		default:
+		}
+		return nil
+	}
+
+	errCh := make(chan error, 1)
+	reportErrorF := func(err error) {
+		select {
+		case errCh <- err:
+		default:
+		}
+	}
+
+	tcc := &testutils.ResolverClientConn{Logger: t, UpdateStateF: updateStateF, ReportErrorF: reportErrorF}
+	// Create a delegating resolver with no proxy configuration
+	dr, err := New(resolver.Target{URL: *testutils.MustParseURL(target)}, tcc, resolver.BuildOptions{}, mr)
+	if err != nil || dr == nil {
+		t.Fatalf("Failed to create delegating resolver: %v", err)
+	}
+
+	// Update the manual resolver with a test address.
+	mr.UpdateState(resolver.State{Addresses: []resolver.Address{{Addr: "test-addr"}}, ServiceConfig: &serviceconfig.ParseResult{}})
+
+	// Verify that the delegating resolver outputs the same address.
+	select {
+	case state := <-stateCh:
+		if len(state.Addresses) != 1 || state.Addresses[0].Addr != "test-addr" {
+			t.Errorf("Unexpected address from delegating resolver: %v, want [test-addr]", state.Addresses)
+		}
+	default:
+	}
+}

--- a/resolver_wrapper.go
+++ b/resolver_wrapper.go
@@ -26,6 +26,8 @@ import (
 	"google.golang.org/grpc/internal/channelz"
 	"google.golang.org/grpc/internal/grpcsync"
 	"google.golang.org/grpc/internal/pretty"
+
+	"google.golang.org/grpc/internal/resolver/delegatingresolver"
 	"google.golang.org/grpc/resolver"
 	"google.golang.org/grpc/serviceconfig"
 )
@@ -78,7 +80,11 @@ func (ccr *ccResolverWrapper) start() error {
 			Authority:            ccr.cc.authority,
 		}
 		var err error
-		ccr.resolver, err = ccr.cc.resolverBuilder.Build(ccr.cc.parsedTarget, ccr, opts)
+		if ccr.cc.dopts.copts.UseProxy || ccr.cc.dopts.copts.Dialer != nil {
+			ccr.resolver, err = delegatingresolver.New(ccr.cc.parsedTarget, ccr, opts, ccr.cc.resolverBuilder)
+		} else {
+			ccr.resolver, err = ccr.cc.resolverBuilder.Build(ccr.cc.parsedTarget, ccr, opts)
+		}
 		errCh <- err
 	})
 	return <-errCh


### PR DESCRIPTION
Making the delegating resolver call targetURI resolver unconditionally
THis does not change any behaviour for the users